### PR TITLE
WIP: Add endpoints that use UncEADConverter and SimpleUncEADConverter

### DIFF
--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -25,6 +25,14 @@ unless AppConfig.has_key?(:converter_tree)
       },
     },
     resource: {
+      unc_ead: {
+          converter_class: UncEADConverter,
+          parse_method: :parse_as_xml,
+      },
+      simple_unc_ead: {
+          converter_class: SimpleUncEADConverter,
+          parse_method: :parse_as_xml,
+      },
       ead: {
           converter_class: EADConverter,
           parse_method: :parse_as_xml,


### PR DESCRIPTION
Relies on aspace-local ead-converter branch: https://gitlab.lib.unc.edu/cappdev/aspace-local/-/merge_requests/8

Realized I had to pull both endpoints out of main branch because aspace-jsonmodel-from-format is on prod and aspace-test now, but aspace-local ead-converter is NOT yet. Can merge as part of https://jira.lib.unc.edu/browse/AS-88